### PR TITLE
Widget fix

### DIFF
--- a/postBuild
+++ b/postBuild
@@ -8,11 +8,11 @@ test -e test.png && rm test.png
 # install and activate extensions in py2 env
 source /srv/venv2/bin/activate
 
-pip install ipywidgets==6.0.1 && \
+pip install ipywidgets==6.0.1 widgetsnbextension==2.0  && \
 jupyter nbextension install --py --sys-prefix widgetsnbextension && \
 jupyter nbextension enable --py widgetsnbextension --sys-prefix
 
-pip install pythreejs==0.3.1 widgetsnbextension==2.0 && \
+pip install pythreejs==0.3.1 && \
 jupyter nbextension install --py --sys-prefix pythreejs && \
 jupyter nbextension enable --py pythreejs --sys-prefix
 

--- a/postBuild
+++ b/postBuild
@@ -6,7 +6,6 @@ python -c "import matplotlib as mpl; mpl.use('Agg'); import pylab as plt; fig, a
 test -e test.png && rm test.png
 
 # install and activate extensions in py2 env
-#source /srv/venv2/bin/activate
 source activate /srv/conda/envs/kernel 
 
 pip install ipywidgets==6.0.1 widgetsnbextension==2.0.1  && \
@@ -20,6 +19,7 @@ jupyter nbextension enable --py pythreejs --sys-prefix
 deactivate
 
 # install pythreejs in py3 environment so that things match
+source activate /srv/conda
 
 pip install ipywidgets==6.0.1 widgetsnbextension==2.0.1  && \
 jupyter nbextension install --py --sys-prefix widgetsnbextension && \

--- a/postBuild
+++ b/postBuild
@@ -9,7 +9,7 @@ test -e test.png && rm test.png
 #source /srv/venv2/bin/activate
 source activate /srv/conda/envs/kernel 
 
-pip install ipywidgets==6.0.1 widgetsnbextension==2.0  && \
+pip install ipywidgets==6.0.1 widgetsnbextension==2.0.1  && \
 jupyter nbextension install --py --sys-prefix widgetsnbextension && \
 jupyter nbextension enable --py widgetsnbextension --sys-prefix
 
@@ -20,6 +20,11 @@ jupyter nbextension enable --py pythreejs --sys-prefix
 deactivate
 
 # install pythreejs in py3 environment so that things match
+
+pip install ipywidgets==6.0.1 widgetsnbextension==2.0.1  && \
+jupyter nbextension install --py --sys-prefix widgetsnbextension && \
+jupyter nbextension enable --py widgetsnbextension --sys-prefix
+
 pip install pythreejs==0.3.1  && \
 jupyter nbextension install --py --sys-prefix pythreejs && \
 jupyter nbextension enable --py pythreejs --sys-prefix

--- a/postBuild
+++ b/postBuild
@@ -6,7 +6,8 @@ python -c "import matplotlib as mpl; mpl.use('Agg'); import pylab as plt; fig, a
 test -e test.png && rm test.png
 
 # install and activate extensions in py2 env
-source /srv/venv2/bin/activate
+#source /srv/venv2/bin/activate
+source activate /srv/conda/envs/kernel 
 
 pip install ipywidgets==6.0.1 widgetsnbextension==2.0  && \
 jupyter nbextension install --py --sys-prefix widgetsnbextension && \

--- a/postBuild
+++ b/postBuild
@@ -12,7 +12,7 @@ pip install ipywidgets==6.0.1 && \
 jupyter nbextension install --py --sys-prefix widgetsnbextension && \
 jupyter nbextension enable --py widgetsnbextension --sys-prefix
 
-pip install pythreejs==0.3.1  && \
+pip install pythreejs==0.3.1 widgetsnbextension==2.0 && \
 jupyter nbextension install --py --sys-prefix pythreejs && \
 jupyter nbextension enable --py pythreejs --sys-prefix
 


### PR DESCRIPTION
Updating the postBuild script in response to issue #1 

The change was to explicitly force widgetsnbextension to be installed as version 2.0.1 on both the py2 and py3 kernel environments.

This is necessary because ipywidgest and pythreejs are also locked to specific versions, ultimately due to how the CQNB library is currently built.

For the time being, this is a workable environment and is acceptable